### PR TITLE
Refresh folder sizes after tree operations

### DIFF
--- a/.github/workflows/package-folder-size-subtree-refresh-lean.yml
+++ b/.github/workflows/package-folder-size-subtree-refresh-lean.yml
@@ -1,0 +1,60 @@
+name: Package folder size subtree refresh test image (lean)
+
+on:
+  push:
+    branches:
+      - agent/folder-size-subtree-refresh
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: explorer
+  IMAGE_TAG: folder-size-subtree-refresh-lean
+
+concurrency:
+  group: package-folder-size-subtree-refresh-lean-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish lean test image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            REPO_URL=https://github.com/${{ github.repository }}
+            INCLUDE_VAAPI=false
+            INCLUDE_RAW=false
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/package-folder-size-subtree-refresh.yml
+++ b/.github/workflows/package-folder-size-subtree-refresh.yml
@@ -1,0 +1,58 @@
+name: Package folder size subtree refresh test image
+
+on:
+  push:
+    branches:
+      - agent/folder-size-subtree-refresh
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: explorer
+  IMAGE_TAG: folder-size-subtree-refresh
+
+concurrency:
+  group: package-folder-size-subtree-refresh-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish test image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            REPO_URL=https://github.com/${{ github.repository }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/backend/src/routes/collabora.js
+++ b/backend/src/routes/collabora.js
@@ -14,6 +14,7 @@ const logger = require('../utils/logger');
 const { getDiscoveryActionsByExt } = require('../services/collaboraDiscoveryService');
 const lockService = require('../services/wopiLockService');
 const { ValidationError, UnauthorizedError, ForbiddenError } = require('../errors/AppError');
+const folderSizeHooks = require('../services/folderSizeHooks');
 
 const router = express.Router();
 
@@ -274,6 +275,15 @@ router.post(
 
     const abs = tokenPayload.absolutePath;
     await ensureDir(path.dirname(abs));
+    let previousSize = 0;
+    let existed = false;
+    try {
+      const previous = await fsp.stat(abs);
+      existed = previous.isFile();
+      previousSize = existed ? previous.size : 0;
+    } catch {
+      // A newly-created document is valid.
+    }
 
     const requestLock = (req.headers['x-wopi-lock'] || '').toString();
     const currentLock = lockService.getLock(fileId);
@@ -295,6 +305,11 @@ router.post(
 
     await fsp.rename(tmp, abs);
     const stat = await fsp.stat(abs);
+    if (existed) {
+      await folderSizeHooks.onFileReplaced(abs, previousSize, stat.size);
+    } else {
+      await folderSizeHooks.onFileWritten(abs, stat.size);
+    }
 
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader('X-WOPI-ItemVersion', versionFromStat(stat));

--- a/backend/src/routes/editor.js
+++ b/backend/src/routes/editor.js
@@ -13,6 +13,7 @@ const {
   NotFoundError,
   UnsupportedMediaTypeError,
 } = require('../errors/AppError');
+const folderSizeHooks = require('../services/folderSizeHooks');
 
 const router = express.Router();
 
@@ -154,7 +155,22 @@ router.put(
     const { absolutePath } = resolved;
 
     await ensureDir(path.dirname(absolutePath));
+    let previousSize = 0;
+    let existed = false;
+    try {
+      const previous = await fs.stat(absolutePath);
+      existed = previous.isFile();
+      previousSize = existed ? previous.size : 0;
+    } catch {
+      // A new file is the expected path.
+    }
     await fs.writeFile(absolutePath, content, { encoding: 'utf-8' });
+    const updated = await fs.stat(absolutePath);
+    if (existed) {
+      await folderSizeHooks.onFileReplaced(absolutePath, previousSize, updated.size);
+    } else {
+      await folderSizeHooks.onFileWritten(absolutePath, updated.size);
+    }
     res.send({ success: true });
   })
 );

--- a/backend/src/routes/onlyoffice.js
+++ b/backend/src/routes/onlyoffice.js
@@ -13,6 +13,7 @@ const { resolvePathWithAccess } = require('../services/accessManager');
 const logger = require('../utils/logger');
 const asyncHandler = require('../utils/asyncHandler');
 const { ValidationError, UnauthorizedError, ForbiddenError } = require('../errors/AppError');
+const folderSizeHooks = require('../services/folderSizeHooks');
 
 const router = express.Router();
 
@@ -308,6 +309,15 @@ router.post(
           abs = resolved.absolutePath;
         }
         await ensureDir(path.dirname(abs));
+        let previousSize = 0;
+        let existed = false;
+        try {
+          const previous = await fsp.stat(abs);
+          existed = previous.isFile();
+          previousSize = existed ? previous.size : 0;
+        } catch {
+          // A newly-created document is valid.
+        }
         // Download updated file from Document Server
         const response = await axios.get(body.url, { responseType: 'stream' });
         await fsp.writeFile(abs, Buffer.from([])); // ensure file exists / truncate
@@ -317,6 +327,12 @@ router.post(
           writeStream.on('finish', resolve);
           writeStream.on('error', reject);
         });
+        const updated = await fsp.stat(abs);
+        if (existed) {
+          await folderSizeHooks.onFileReplaced(abs, previousSize, updated.size);
+        } else {
+          await folderSizeHooks.onFileWritten(abs, updated.size);
+        }
         logger.debug({ path: relativePath }, 'ONLYOFFICE file updated');
         // MUST return {error:0} according to ONLYOFFICE spec
         return res.json({ error: 0 });

--- a/backend/src/routes/zip.js
+++ b/backend/src/routes/zip.js
@@ -15,6 +15,7 @@ const {
 } = require('../utils/pathUtils');
 const { ValidationError, ForbiddenError, NotFoundError } = require('../errors/AppError');
 const { ACTIONS, authorizeAndResolve } = require('../services/authorizationService');
+const folderSizeHooks = require('../services/folderSizeHooks');
 
 const router = express.Router();
 
@@ -112,6 +113,10 @@ router.post(
       throw error;
     }
 
+    // The archive has produced an entire new tree. Index it now rather than
+    // waiting for each nested directory to be visited in the UI.
+    await folderSizeHooks.onDirectoryTreeCreated(destinationFolderAbsolutePath);
+
     const item = await buildItemMetadata(
       destinationFolderAbsolutePath,
       parentRelativePath,
@@ -191,6 +196,9 @@ router.post(
         : zip.addLocalFile(absolutePath, '', entryName);
     });
     zip.writeZip(zipAbsolutePath);
+
+    const zipStats = await fs.stat(zipAbsolutePath);
+    await folderSizeHooks.onFileWritten(zipAbsolutePath, zipStats.size);
 
     const item = await buildItemMetadata(zipAbsolutePath, normalizedDestination, zipFileName);
     res.status(201).json({ success: true, item });

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -124,7 +124,7 @@ const transferItems = async (items, destination, operation, options = {}) => {
 
     if (operation === 'copy') {
       await copyEntry(sourceAbsolute, targetAbsolute, stats.isDirectory());
-      folderSizeHooks.onEntryCopied(targetAbsolute, {
+      await folderSizeHooks.onEntryCopied(targetAbsolute, {
         isDirectory: stats.isDirectory(),
         size: stats.size,
         sourceAbsolutePath: sourceAbsolute,

--- a/backend/src/services/folderSizeHooks.js
+++ b/backend/src/services/folderSizeHooks.js
@@ -20,6 +20,7 @@ const logger = require('../utils/logger');
 const { getDb } = require('./db');
 const folderSizeIndex = require('./folderSizeIndex');
 const { getVolumeScope } = require('./folderSizeIndexer');
+const folderSizeManager = require('./folderSizeManager');
 
 const isEnabled = () => config.folderSize.enabled;
 
@@ -28,7 +29,7 @@ const withIndex = async (fn) => {
   try {
     const db = await getDb();
     const scope = getVolumeScope();
-    fn(db, scope);
+    return await fn(db, scope);
   } catch (err) {
     logger.debug({ err, component: 'folderSizeIndexer' }, 'Folder size hook failed (non-fatal)');
   }
@@ -42,6 +43,17 @@ const onFileWritten = (absolutePath, size) =>
     });
   });
 
+/** A file was replaced in place; only its byte delta changes the index. */
+const onFileReplaced = (absolutePath, previousSize, size) =>
+  withIndex((db, scope) => {
+    folderSizeIndex.applyDelta(
+      db,
+      scope,
+      path.dirname(absolutePath),
+      (Number(size) || 0) - (Number(previousSize) || 0)
+    );
+  });
+
 /** An empty folder has been created at `absolutePath`. */
 const onFolderCreated = (absolutePath) =>
   withIndex((db, scope) => {
@@ -53,6 +65,23 @@ const onFolderCreated = (absolutePath) =>
     });
     folderSizeIndex.applyDelta(db, scope, path.dirname(absolutePath), 0, { entryDelta: 1 });
   });
+
+/**
+ * A complete directory tree was created by an application operation. The
+ * manager scans this tree alone and applies one precise delta to its parent.
+ */
+const onDirectoryTreeCreated = async (absolutePath) => {
+  if (!isEnabled()) return null;
+  try {
+    return await folderSizeManager.refreshSubtree(absolutePath);
+  } catch (err) {
+    logger.debug(
+      { err, component: 'folderSizeIndexer' },
+      'Folder subtree index refresh failed (non-fatal)'
+    );
+    return null;
+  }
+};
 
 /**
  * An entry has been deleted. For a file the size is known; for a directory the
@@ -100,18 +129,18 @@ const onEntryMoved = (sourceAbsolutePath, targetAbsolutePath, meta = {}) =>
 
 /**
  * An entry has been copied to `targetAbsolutePath`. The destination gains the
- * copied bytes; for a copied directory its inner folders are (re)discovered by
- * the watcher / reconciliation — the top entry is created here as a placeholder.
+ * copied bytes. A copied directory is scanned immediately so its child index
+ * entries and recursive size are available before the operation completes.
  */
-const onEntryCopied = (targetAbsolutePath, meta = {}) =>
-  withIndex((db, scope) => {
-    const bytes = meta.isDirectory
-      ? sizeOfMoved(db, scope, meta.sourceAbsolutePath, meta)
-      : Number(meta.size) || 0;
+const onEntryCopied = async (targetAbsolutePath, meta = {}) => {
+  if (meta.isDirectory) return onDirectoryTreeCreated(targetAbsolutePath);
+  return withIndex((db, scope) => {
+    const bytes = Number(meta.size) || 0;
     folderSizeIndex.applyDelta(db, scope, path.dirname(targetAbsolutePath), bytes, {
       entryDelta: 1,
     });
   });
+};
 
 /**
  * An entry has been renamed in place (same parent directory). Bytes and parent
@@ -127,7 +156,9 @@ const onEntryRenamed = (sourceAbsolutePath, targetAbsolutePath) =>
 
 module.exports = {
   onFileWritten,
+  onFileReplaced,
   onFolderCreated,
+  onDirectoryTreeCreated,
   onEntryDeleted,
   onEntryMoved,
   onEntryCopied,

--- a/backend/src/services/folderSizeIndexer.js
+++ b/backend/src/services/folderSizeIndexer.js
@@ -107,14 +107,14 @@ const absOf = (scope, relativePath) =>
   relativePath ? path.join(scope.root, relativePath) : scope.root;
 
 /**
- * Recursively walk `scope.root`, writing an authoritative index entry for every
+ * Recursively walk `rootAbs`, writing an authoritative index entry for every
  * folder. Directory sizes are recursive in `full` mode and direct-entries-only
  * in `shallow` mode. Writes happen in batched transactions and the event loop
  * is yielded between batches so the walk never starves concurrent HTTP work.
  *
  * @returns {Promise<{ folders: number, bytes: number }>}
  */
-const runBaseline = async (db, scope, options = {}) => {
+const scanTree = async (db, scope, rootAbs, options = {}) => {
   const {
     mode = config.folderSize.mode || 'full',
     concurrency = resolveConcurrency(scope, options),
@@ -158,8 +158,9 @@ const runBaseline = async (db, scope, options = {}) => {
   // Only the leaf I/O (readdir, stat) goes through the concurrency limiter, and a
   // frame never holds a limiter slot while awaiting a child — so it cannot
   // deadlock on deep trees the way limiting the recursion itself would.
-  const stack = [newFrame(scope.root)];
+  const stack = [newFrame(rootAbs)];
   let rootTotal = 0;
+  let rootEntryCount = 0;
 
   while (stack.length) {
     if (signal?.aborted) break;
@@ -228,13 +229,41 @@ const runBaseline = async (db, scope, options = {}) => {
       stack[stack.length - 1].childrenBytes += recursiveTotal;
     } else {
       rootTotal = recursiveTotal;
+      rootEntryCount = frame.entryCount;
     }
 
     if (folders % yieldEvery === 0) await yieldToEventLoop();
   }
 
   flush();
-  return { folders, bytes: rootTotal };
+  return { folders, bytes: rootTotal, entryCount: rootEntryCount };
+};
+
+/** Run a full authoritative scan of the configured volume root. */
+const runBaseline = (db, scope, options = {}) => scanTree(db, scope, scope.root, options);
+
+/**
+ * Index a newly-created directory tree and apply its resulting size exactly
+ * once to the parent chain. This is the completion path for operations such as
+ * ZIP extraction and directory copy: it avoids an eventual, view-driven walk
+ * while keeping the scan limited to the newly produced subtree.
+ */
+const indexSubtree = async (db, scope, absDir, options = {}) => {
+  if (!folderSizeIndex.isWithinRoot(scope.root, absDir)) return null;
+
+  const mode = options.mode || config.folderSize.mode || 'full';
+  const previous = folderSizeIndex.getByAbsolutePath(db, absDir);
+  const result = await scanTree(db, scope, absDir, { ...options, mode });
+
+  if (absDir !== scope.root) {
+    // In shallow mode parents deliberately exclude their child folders' bytes.
+    const byteDelta = mode === 'full' ? result.bytes - (previous?.sizeBytes || 0) : 0;
+    folderSizeIndex.applyDelta(db, scope, path.dirname(absDir), byteDelta, {
+      entryDelta: previous ? 0 : 1,
+    });
+  }
+
+  return result;
 };
 
 /**
@@ -420,6 +449,7 @@ module.exports = {
   isStale,
   nextReconcileDelay,
   runBaseline,
+  indexSubtree,
   aggregateDirectory,
   applyAggregate,
   removeMissing,

--- a/backend/src/services/folderSizeManager.js
+++ b/backend/src/services/folderSizeManager.js
@@ -4,11 +4,12 @@
  * Everything runs on the main thread to keep RAM low: no worker thread (no
  * second V8 isolate, no second SQLite connection) and no recursive filesystem
  * watcher (recursive inotify holds memory proportional to the directory count).
- * Heavy work still stays off the request path because it is fully async
+ * Heavy work stays out of read/navigation paths. A mutating operation may await
+ * the final index of the subtree it created, but that scan is fully async
  * (readdir/stat), writes to SQLite in small batched transactions, and yields to
- * the event loop between batches — so Express keeps serving while indexing
- * proceeds. We deliberately do NOT lower the process priority here (on the main
- * thread that would nice request handling too).
+ * the event loop between batches — so Express keeps serving while it proceeds.
+ * We deliberately do NOT lower the process priority here (on the main thread
+ * that would nice request handling too).
  *
  * Freshness has three layers:
  *   1. write hooks — NextExplorer's own operations update the index instantly;
@@ -41,6 +42,13 @@ let reconcileTimer = null;
 let reconcileDelay = 0;
 let reconciling = false;
 let abortController = null;
+
+// Targeted scans are serialized with each other. A completed filesystem
+// operation can therefore await an exact subtree index without racing another
+// operation's ancestor delta or the SQLite writes it produces.
+let subtreeScanChain = Promise.resolve();
+const pendingSubtreeScans = new Map();
+let readyPromise = null;
 
 const log = (level, message, extra = {}) =>
   logger[level]({ component: 'folderSizeIndexer', ...extra }, message);
@@ -79,7 +87,9 @@ const flush = async () => {
     const ops = [];
     for (const abs of dirs) {
       // eslint-disable-next-line no-await-in-loop
-      const agg = await indexer.aggregateDirectory(db, scope, abs, { mode: config.folderSize.mode });
+      const agg = await indexer.aggregateDirectory(db, scope, abs, {
+        mode: config.folderSize.mode,
+      });
       ops.push({ abs, agg });
     }
 
@@ -218,10 +228,12 @@ const start = () => {
   if (running || starting) return;
   starting = true;
   stopped = false;
-  init().catch((err) => {
+  readyPromise = init().catch((err) => {
     starting = false;
     log('error', 'Folder size indexer failed to start', { err });
+    throw err;
   });
+  readyPromise.catch(() => {});
 };
 
 const stop = async () => {
@@ -257,11 +269,45 @@ const requestRebuild = () => {
   })();
 };
 
+/**
+ * Queue an authoritative scan of one newly-created directory tree. Calls for
+ * the same path share the same work. During startup this waits for the baseline
+ * instead of returning a stale size for a completed operation.
+ */
+const refreshSubtree = async (absDir) => {
+  if (!config.folderSize.enabled || stopped || (!running && !starting)) return null;
+  if (pendingSubtreeScans.has(absDir)) return pendingSubtreeScans.get(absDir);
+
+  const scan = async () => {
+    if (starting && readyPromise) await readyPromise;
+    if (!running || !db || !scope || stopped) return null;
+
+    const startedAt = Date.now();
+    const result = await indexer.indexSubtree(db, scope, absDir, {
+      mode: config.folderSize.mode,
+    });
+    if (result?.folders >= 300) reclaimMemory();
+    log('debug', 'Indexed completed directory tree', {
+      path: absDir,
+      ...result,
+      ms: Date.now() - startedAt,
+    });
+    return result;
+  };
+
+  const queued = subtreeScanChain.then(scan, scan);
+  subtreeScanChain = queued.catch(() => {});
+  pendingSubtreeScans.set(absDir, queued);
+  queued.finally(() => pendingSubtreeScans.delete(absDir)).catch(() => {});
+  return queued;
+};
+
 module.exports = {
   start,
   stop,
   touch,
   requestReconcile,
   requestRebuild,
+  refreshSubtree,
   isRunning: () => running,
 };

--- a/backend/tests/services/folderSizeIndexer.test.js
+++ b/backend/tests/services/folderSizeIndexer.test.js
@@ -87,6 +87,30 @@ describe('folderSizeIndexer', () => {
     expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'A', 'B')).entryCount).toBe(2);
   });
 
+  it('indexes a newly-created subtree and updates its ancestors in one pass', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'Existing'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'Existing', 'before'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    // Mirrors archive extraction: the new tree did not exist in the baseline.
+    const extracted = path.join(vol, 'Existing', 'Extracted');
+    await fs.mkdir(path.join(extracted, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(extracted, 'top.bin'), Buffer.alloc(20));
+    await fs.writeFile(path.join(extracted, 'nested', 'payload.bin'), Buffer.alloc(70));
+
+    const result = await indexer.indexSubtree(db, scope, extracted, { mode: 'full' });
+
+    expect(result).toMatchObject({ folders: 2, bytes: 90 });
+    expect(sizeOf(folderSizeIndex, db, extracted)).toBe(90);
+    expect(sizeOf(folderSizeIndex, db, path.join(extracted, 'nested'))).toBe(70);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'Existing'))).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(100);
+  });
+
   it('reconciliation detects and corrects an out-of-band change via mtime', async () => {
     ctx = await createContext();
     const { env, db, folderSizeIndex, indexer, scope } = ctx;
@@ -193,7 +217,7 @@ describe('folderSizeIndexer', () => {
     expect(sizeOf(folderSizeIndex, db, vol)).toBe(100);
   });
 
-  it('shallow mode stores only each folder\'s direct file bytes', async () => {
+  it("shallow mode stores only each folder's direct file bytes", async () => {
     ctx = await createContext();
     const { env, db, folderSizeIndex, indexer, scope } = ctx;
     const vol = env.volumeDir;


### PR DESCRIPTION
## Summary

Refreshes the SQLite folder-size index when an application operation creates a complete directory tree.

## Root cause

Archive extraction and directory copy created nested folders that were unknown to the index. The parent aggregate therefore counted them as zero until each subfolder was visited.

## Changes

- scan only the newly-created subtree after extraction or directory copy;
- serialize subtree scans and apply one ancestor delta when complete;
- refresh file-size deltas after compression, editor saves, OnlyOffice and Collabora saves;
- preserve existing bounded concurrency, batched SQLite writes and event-loop yields.

## Validation

- `npm test -- tests/services/folderSizeIndexer.test.js`
- `npm test -- tests/routes/folderSize.test.js`
- syntax and Prettier checks

Depends on nxzai/NextExplorer#320 because it extends the folder-size index introduced there.