### PR TITLE
Sign in with a username, and the answer to running as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Two images are published, on both registries:
 
 | Tag                         | Contains                                                                         |
 | --------------------------- | -------------------------------------------------------------------------------- |
-| `latest`, `3.3.0`           | Everything, including hardware video acceleration (VA-API) and RAW photo support |
-| `latest-lean`, `3.3.0-lean` | The same application without VA-API or RAW — a considerably smaller image        |
+| `latest`, `3.4.0`           | Everything, including hardware video acceleration (VA-API) and RAW photo support |
+| `latest-lean`, `3.4.0-lean` | The same application without VA-API or RAW — a considerably smaller image        |
 
 Take the full image unless you know you need neither: VA-API only helps where the host exposes a render device to the container, and RAW support only matters if you keep camera files. Both variants are built for `linux/amd64` and `linux/arm64`.
 
@@ -49,7 +49,7 @@ They are also on Docker Hub under the same tags.
 
 `latest` and `latest-lean` follow `main`, so a fix reaches them without waiting
 for a release. Every build is also published under the version in
-`package.json` — `3.3.0`, `3.3.0-lean` — republished for as long as that
+`package.json` — `3.4.0`, `3.4.0-lean` — republished for as long as that
 version is current, and left alone once the next one is cut.
 
 Only the last two versions stay published: on Docker Hub the older one is

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finder",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "explorer",
   "main": "src/server.js",
   "engines": {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -148,18 +148,19 @@ router.post(
   })
 );
 
-// Local login with email + password
+// Local login with an email address or a username, and a password
 router.post(
   '/login',
   loginLimiter,
   asyncHandler(async (req, res) => {
-    const { email, password, username } = req.body || {};
-    // Support both email and username (backward compatibility)
-    const emailOrUsername = email || username;
+    const { identifier, email, password, username } = req.body || {};
+    // `email` and `username` are the older field names; both carried whatever
+    // was typed into the one box on the sign-in screen.
+    const typed = identifier || email || username;
 
     let user = null;
     try {
-      user = await attemptLocalLogin({ email: emailOrUsername, password });
+      user = await attemptLocalLogin({ identifier: typed, password });
     } catch (e) {
       if (e?.status === 423) {
         throw new RateLimitError(e.message, e.until);

--- a/backend/src/services/users/localAuth.js
+++ b/backend/src/services/users/localAuth.js
@@ -1,7 +1,7 @@
 const bcrypt = require('bcryptjs');
 const { getDb } = require('../db');
 const logger = require('../../utils/logger');
-const { nowIso, toClientUser, generateId, normalizeEmail } = require('./utils');
+const { nowIso, toClientUser, generateId, normalizeEmail, usernameTaken } = require('./utils');
 const { isLocked, incrementFailedAttempts, clearLock, getLock } = require('./lockout');
 const {
   NotFoundError,
@@ -11,30 +11,74 @@ const {
 } = require('../../errors/AppError');
 const { ErrorCodes } = require('../../errors/errorCodes');
 
-// Attempt local login with email + password
-const attemptLocalLogin = async ({ email, password }) => {
-  const normEmail = normalizeEmail(email);
+/**
+ * The account someone means by what they typed, or null.
+ *
+ * An email is looked up first: it is unique by schema, so it can never be
+ * ambiguous. A username is not — the column carries no uniqueness constraint,
+ * and `createLocalUser` derives one from the local part of the address, so two
+ * people on different domains genuinely can end up as `alice`.
+ *
+ * Where a name matches more than one account it identifies nobody, and picking
+ * one would be choosing whose account a stranger signs into. Those accounts
+ * keep their email, which is unambiguous by construction.
+ */
+const findUserByIdentifier = (db, typed) => {
+  const trimmed = typeof typed === 'string' ? typed.trim() : '';
+  if (!trimmed) return null;
 
-  // Check lockout
-  if (await isLocked(normEmail)) {
-    const lock = await getLock(normEmail);
+  const byEmail = db.prepare('SELECT * FROM users WHERE email = ?').get(normalizeEmail(trimmed));
+  if (byEmail) return byEmail;
+
+  // Without regard to case, because nobody remembers whether they capitalised
+  // their own name — and because the column would let `Alice` and `alice` be
+  // two accounts, which is exactly the ambiguity refused below.
+  const matches = db
+    .prepare(
+      "SELECT * FROM users WHERE username IS NOT NULL AND username <> '' AND lower(username) = lower(?)"
+    )
+    .all(trimmed);
+
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    logger.warn(
+      { username: trimmed, accounts: matches.length },
+      'Several accounts share this username; it cannot be used to sign in. They can use their email address.'
+    );
+  }
+  return null;
+};
+
+/**
+ * Sign in with an email address or a username, and a password.
+ *
+ * @param {{identifier?: string, email?: string, password: string}} credentials
+ *   `email` is accepted as the older name for `identifier`.
+ */
+const attemptLocalLogin = async ({ identifier, email, password }) => {
+  const db = await getDb();
+
+  const user = findUserByIdentifier(db, identifier ?? email);
+  if (!user) {
+    // No counter for something that names no account. The lock is per account,
+    // so counting here would let anyone lock a colleague out by guessing at
+    // their address. Brute force is bounded by the login rate limit.
+    return null;
+  }
+
+  // Keyed on the account rather than on what was typed. One account answering
+  // to two names would otherwise get one lockout budget per name, and anyone
+  // alternating between them would never exhaust either.
+  const lockKey = user.id;
+
+  if (await isLocked(lockKey)) {
+    const lock = await getLock(lockKey);
     const until = lock.locked_until || null;
     const err = new Error('Account is temporarily locked due to failed login attempts.');
     err.status = 423;
     err.code = ErrorCodes.AUTH_ACCOUNT_LOCKED;
     err.until = until;
     throw err;
-  }
-
-  const db = await getDb();
-
-  // Find user by email
-  const user = db.prepare('SELECT * FROM users WHERE email = ?').get(normEmail);
-  if (!user) {
-    // No counter for an address that has no account: the lock is keyed on the
-    // email alone, so counting here would let anyone lock a colleague out by
-    // guessing their address. Brute force is bounded by the login rate limit.
-    return null;
   }
 
   // Find local password auth method
@@ -48,19 +92,19 @@ const attemptLocalLogin = async ({ email, password }) => {
     .get(user.id);
 
   if (!authMethod || !authMethod.password_hash) {
-    await incrementFailedAttempts(normEmail);
+    await incrementFailedAttempts(lockKey);
     return null;
   }
 
   // Verify password
   const valid = await bcrypt.compare(password || '', authMethod.password_hash);
   if (!valid) {
-    await incrementFailedAttempts(normEmail);
+    await incrementFailedAttempts(lockKey);
     return null;
   }
 
   // Success - clear lockout
-  await clearLock(normEmail);
+  await clearLock(lockKey);
   db.prepare('UPDATE auth_methods SET last_used_at = ? WHERE id = ?').run(nowIso(), authMethod.id);
 
   let clientUser = toClientUser(user);
@@ -85,6 +129,13 @@ const createLocalUser = async ({ email, password, username, displayName, roles =
       null,
       ErrorCodes.VALIDATION_PASSWORD_TOO_SHORT
     );
+  }
+
+  // A username is something to sign in with, so it has to name one account.
+  // Nothing removes the duplicates an older version allowed; this stops more
+  // being made.
+  if (usernameTaken(db, username)) {
+    throw new ConflictError('Username already in use', ErrorCodes.CONFLICT_USER_EXISTS);
   }
 
   // Check if user exists

--- a/backend/src/services/users/management.js
+++ b/backend/src/services/users/management.js
@@ -1,5 +1,5 @@
 const { getDb } = require('../db');
-const { toClientUser, toShareableUser, normalizeEmail, nowIso } = require('./utils');
+const { toClientUser, toShareableUser, normalizeEmail, nowIso, usernameTaken } = require('./utils');
 const { countAdmins } = require('./queries');
 
 const listUsers = async () => {
@@ -75,6 +75,12 @@ const updateUserProfile = async ({ userId, email, username, displayName }) => {
 
   if (typeof username === 'string') {
     const trimmed = username.trim();
+    // A username is something to sign in with, so it has to name one account.
+    if (trimmed && usernameTaken(db, trimmed, userId)) {
+      const err = new Error('Username already in use.');
+      err.status = 409;
+      throw err;
+    }
     updates.push('username = ?');
     values.push(trimmed || null);
   }

--- a/backend/src/services/users/utils.js
+++ b/backend/src/services/users/utils.js
@@ -35,10 +35,35 @@ const toShareableUser = (row) => {
   };
 };
 
+/**
+ * Whether a username is already answering for another account.
+ *
+ * Compared without regard to case, because that is how it is matched at sign
+ * in: allowing `Alice` alongside `alice` would create a name that identifies
+ * two accounts and therefore signs nobody in.
+ *
+ * @param {object} db open database
+ * @param {string} username the name being claimed
+ * @param {string|null} exceptUserId the account claiming it, when it already exists
+ */
+const usernameTaken = (db, username, exceptUserId = null) => {
+  const trimmed = typeof username === 'string' ? username.trim() : '';
+  if (!trimmed) return false;
+
+  const row = db
+    .prepare(
+      `SELECT id FROM users
+       WHERE username IS NOT NULL AND lower(username) = lower(?) AND id <> COALESCE(?, '')`
+    )
+    .get(trimmed, exceptUserId);
+  return Boolean(row);
+};
+
 module.exports = {
   nowIso,
   toClientUser,
   generateId,
   normalizeEmail,
   toShareableUser,
+  usernameTaken,
 };

--- a/backend/tests/services/username-login.test.js
+++ b/backend/tests/services/username-login.test.js
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * Signing in with a username instead of an email address.
+ *
+ * Asked for in issue #5, and the reason is a fair one: a username is what
+ * somebody chose, an address is what their mail provider gave them.
+ *
+ * Two things had to be settled first. A username is not unique in the schema —
+ * the constraint was lost in an early migration, and `createLocalUser` derives
+ * one from the local part of the address, so `alice@example.com` and
+ * `alice@other.org` both become `alice`. A name that answers for two accounts
+ * identifies neither, and choosing between them would be choosing whose account
+ * a stranger signs into.
+ *
+ * And the lockout: it used to be keyed on what was typed. One account with two
+ * names would then have had one budget of failed attempts per name, and anyone
+ * alternating between them would never have exhausted either.
+ */
+
+let envContext;
+let users;
+
+const build = async (env = {}) => {
+  envContext = await setupTestEnv({
+    tag: 'username-login-',
+    env: { AUTH_MAX_FAILED: '3', AUTH_LOCK_MINUTES: '15', ...env },
+    modules: ['src/services/db', 'src/services/users'],
+  });
+  users = envContext.requireFresh('src/services/users');
+};
+
+const makeUser = async (overrides = {}) =>
+  users.createLocalUser({
+    email: 'alice@example.com',
+    username: 'alice',
+    displayName: 'Alice',
+    password: 'motdepasse',
+    roles: ['user'],
+    ...overrides,
+  });
+
+const signIn = (identifier, password = 'motdepasse') =>
+  users.attemptLocalLogin({ identifier, password });
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('signing in', () => {
+  beforeEach(async () => {
+    await build();
+    await makeUser();
+  });
+
+  it('works with the username', async () => {
+    const user = await signIn('alice');
+
+    expect(user?.email).toBe('alice@example.com');
+  });
+
+  it('still works with the email address', async () => {
+    const user = await signIn('alice@example.com');
+
+    expect(user?.username).toBe('alice');
+  });
+
+  /** Nobody remembers whether they capitalised their own name. */
+  it('does not mind how the username was capitalised', async () => {
+    expect(await signIn('ALICE')).toBeTruthy();
+    expect(await signIn('Alice')).toBeTruthy();
+  });
+
+  it('does not mind how the address was capitalised either', async () => {
+    expect(await signIn('Alice@Example.COM')).toBeTruthy();
+  });
+
+  it('ignores the spaces around what was typed', async () => {
+    expect(await signIn('  alice  ')).toBeTruthy();
+  });
+
+  it('refuses the right name with the wrong password', async () => {
+    expect(await signIn('alice', 'au-hasard')).toBeNull();
+  });
+
+  it('refuses a name that belongs to nobody', async () => {
+    expect(await signIn('bob')).toBeNull();
+  });
+
+  it('refuses nothing at all', async () => {
+    expect(await signIn('')).toBeNull();
+    expect(await signIn(null)).toBeNull();
+    expect(await signIn('   ')).toBeNull();
+  });
+
+  /** The field used to be called `email`, and callers may still say so. */
+  it('accepts the older name for the field', async () => {
+    const user = await users.attemptLocalLogin({ email: 'alice', password: 'motdepasse' });
+
+    expect(user?.email).toBe('alice@example.com');
+  });
+});
+
+describe('a username that answers for two accounts', () => {
+  /**
+   * The column carries no uniqueness constraint, so an installation upgraded
+   * from an older version can already hold this. Signing in with it would mean
+   * picking one of them, which is picking whose account a stranger reaches.
+   */
+  const seedDuplicates = async () => {
+    const db = await envContext.requireFresh('src/services/db').getDb();
+    await makeUser();
+    await makeUser({ email: 'alice@other.org', username: null });
+    db.prepare('UPDATE users SET username = ? WHERE email = ?').run('alice', 'alice@other.org');
+    return db;
+  };
+
+  beforeEach(async () => {
+    await build();
+  });
+
+  it('signs nobody in', async () => {
+    await seedDuplicates();
+
+    expect(await signIn('alice')).toBeNull();
+  });
+
+  it('leaves both of them their address', async () => {
+    await seedDuplicates();
+
+    expect((await signIn('alice@example.com'))?.email).toBe('alice@example.com');
+    expect((await signIn('alice@other.org'))?.email).toBe('alice@other.org');
+  });
+
+  it('is not created by a new account taking a name already in use', async () => {
+    await makeUser();
+
+    await expect(makeUser({ email: 'alice@other.org' })).rejects.toThrow(/username/i);
+  });
+
+  it('is not created by capitalising it differently either', async () => {
+    await makeUser();
+
+    await expect(makeUser({ email: 'alice@other.org', username: 'Alice' })).rejects.toThrow(
+      /username/i
+    );
+  });
+
+  it('is not created by renaming an account onto another', async () => {
+    const alice = await makeUser();
+    const bob = await makeUser({ email: 'bob@example.com', username: 'bob' });
+
+    await expect(
+      users.updateUserProfile({ userId: bob.id, username: 'ALICE' })
+    ).rejects.toMatchObject({ status: 409 });
+    expect(alice.username).toBe('alice');
+  });
+
+  it('does not stop an account keeping the name it already has', async () => {
+    const alice = await makeUser();
+
+    const updated = await users.updateUserProfile({
+      userId: alice.id,
+      username: 'alice',
+      displayName: 'Alice A.',
+    });
+
+    expect(updated.displayName).toBe('Alice A.');
+  });
+
+  it('does not stop an account clearing its username', async () => {
+    const alice = await makeUser();
+
+    const updated = await users.updateUserProfile({ userId: alice.id, username: '' });
+
+    expect(updated.username).toBeNull();
+  });
+
+  /** An account with no username is not an account named "". */
+  it('is not what two accounts without a username are', async () => {
+    await makeUser({ username: null });
+    await makeUser({ email: 'bob@example.com', username: null });
+
+    expect(await signIn('')).toBeNull();
+  });
+
+  /**
+   * An older version could store an empty string rather than nothing. It names
+   * no account, so it must not stop the next account being created without a
+   * username of its own.
+   */
+  it('is not what an account with an empty username is', async () => {
+    const alice = await makeUser();
+    const db = await envContext.requireFresh('src/services/db').getDb();
+    db.prepare('UPDATE users SET username = ? WHERE id = ?').run('', alice.id);
+
+    await expect(makeUser({ email: 'bob@example.com', username: null })).resolves.toBeTruthy();
+    expect(await signIn('')).toBeNull();
+  });
+});
+
+describe('the lockout after failed attempts', () => {
+  beforeEach(async () => {
+    await build();
+    await makeUser();
+  });
+
+  it('locks the account after enough of them', async () => {
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+
+    await expect(signIn('alice')).rejects.toMatchObject({ status: 423 });
+  });
+
+  /**
+   * One account, two names, one budget. Keyed on what was typed, alternating
+   * between the address and the username would have given twice the attempts —
+   * and with the lock never tripping, indefinitely many.
+   */
+  it('counts attempts against the account, not against the name used', async () => {
+    await signIn('alice', 'faux');
+    await signIn('alice@example.com', 'faux');
+    await signIn('ALICE', 'faux');
+
+    await expect(signIn('alice@example.com')).rejects.toMatchObject({ status: 423 });
+  });
+
+  it('locks the account whichever name is tried afterwards', async () => {
+    await signIn('alice@example.com', 'faux');
+    await signIn('alice@example.com', 'faux');
+    await signIn('alice@example.com', 'faux');
+
+    await expect(signIn('alice')).rejects.toMatchObject({ status: 423 });
+  });
+
+  it('forgets the attempts once one of them works', async () => {
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+
+    expect(await signIn('alice')).toBeTruthy();
+
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+    expect(await signIn('alice')).toBeTruthy();
+  });
+
+  /**
+   * A name that belongs to nobody is not counted at all: the lock is per
+   * account, and counting for an unknown name would let anyone lock a
+   * colleague out by guessing at their address.
+   */
+  it('counts nothing against a name that belongs to nobody', async () => {
+    await signIn('mallory', 'faux');
+    await signIn('mallory', 'faux');
+    await signIn('mallory', 'faux');
+    await signIn('mallory', 'faux');
+
+    expect(await signIn('mallory')).toBeNull();
+  });
+
+  /**
+   * An account that signs in through an identity provider has no password
+   * here. Guessing at one is still guessing, and still counted.
+   */
+  it('counts attempts against an account that has no password', async () => {
+    const db = await envContext.requireFresh('src/services/db').getDb();
+    const alice = db.prepare('SELECT id FROM users WHERE email = ?').get('alice@example.com');
+    db.prepare('DELETE FROM auth_methods WHERE user_id = ?').run(alice.id);
+
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+    await signIn('alice', 'faux');
+
+    await expect(signIn('alice')).rejects.toMatchObject({ status: 423 });
+  });
+
+  it('does not lock one account out by failing on another', async () => {
+    await makeUser({ email: 'bob@example.com', username: 'bob' });
+
+    await signIn('bob', 'faux');
+    await signIn('bob', 'faux');
+    await signIn('bob', 'faux');
+
+    expect(await signIn('alice')).toBeTruthy();
+  });
+});

--- a/docs/admin/guide.md
+++ b/docs/admin/guide.md
@@ -13,6 +13,16 @@ Administrators control users, folders, and security policies through Settings. T
 - Navigate to **Settings → Admin → Users** to add local users, assign roles, and reset passwords.
 - When `USER_VOLUMES=true`, each user profile includes a **Volumes** tab for assigning per-user volumes. See [User volumes](/admin/user-volumes).
 - Local users store credentials in the SQLite database inside your `/config` mount.
+- People sign in with **either their email address or their username**, in the
+  same box. Case does not matter for either.
+- A username has to name one account to be usable for signing in. NextExplorer
+  refuses a new account, or a rename, that would take a username another account
+  already has — but an installation upgraded from an older version may already
+  hold duplicates, because the username is derived from the local part of the
+  address (`alice@example.com` and `alice@other.org` both become `alice`). Where
+  a username answers for more than one account it signs nobody in, and those
+  accounts use their email address instead. Give one of them a different
+  username in **Settings → Admin → Users** to free it.
 - Promote trusted accounts to admin inside the UI—note that demotions are blocked when it would remove the last admin.
 - When OIDC is enabled, users are created automatically on first login (unless `OIDC_AUTO_CREATE_USERS=false`) and elevated to admin if their `groups`, `roles`, or `entitlements` claims match any of the names inside `OIDC_ADMIN_GROUPS`.
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -250,4 +250,30 @@ These variables are available for tuning the share system. The defaults are suit
 
 | Variable       | Description                                                                                                                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PUID`, `PGID` | Map container processes to host user/group IDs so created files have consistent ownership. Defaults to `1000`. The entrypoint adjusts ownership of `/app`, `/config`, and `/cache` accordingly. |
+| `PUID`, `PGID` | Map container processes to host user/group IDs so created files have consistent ownership. Defaults to `1000`. The entrypoint adjusts ownership of `/app`, `/config`, and `/cache` accordingly. Set both to `0` to run as root — see [Running as root](#running-as-root). |
+
+## Running as root
+
+The entrypoint always finishes with `gosu appuser`, so the application runs as
+`appuser` whatever Compose's `user:` says. Setting `user: root` therefore
+changes who runs the entrypoint — which was already root — and not who runs the
+server. The knob is `PUID` and `PGID`:
+
+```yaml
+environment:
+  - PUID=0
+  - PGID=0
+```
+
+The entrypoint renumbers `appuser` to those ids before dropping to it, so the
+server runs as root and can read and write anything the mounts expose.
+
+That is a real choice rather than a default, and worth making deliberately:
+
+- Every file NextExplorer creates on the host is owned by root.
+- A mount of `/` gives it the whole host, `/etc` included, with write access
+  wherever the share or the volume allows writing.
+
+Where the aim is only to reach a folder the container cannot currently read,
+matching its owner is usually enough — `PUID` and `PGID` set to that owner's
+ids, which is what they are for.

--- a/docs/installation/deployment.md
+++ b/docs/installation/deployment.md
@@ -14,8 +14,8 @@ Two images are published, on both registries:
 
 | Tag                         | Contains                                                                         |
 | --------------------------- | -------------------------------------------------------------------------------- |
-| `latest`, `3.3.0`           | Everything, including hardware video acceleration (VA-API) and RAW photo support |
-| `latest-lean`, `3.3.0-lean` | The same application without VA-API or RAW — a considerably smaller image        |
+| `latest`, `3.4.0`           | Everything, including hardware video acceleration (VA-API) and RAW photo support |
+| `latest-lean`, `3.4.0-lean` | The same application without VA-API or RAW — a considerably smaller image        |
 
 Take the full image unless you know you need neither: VA-API only helps where the host exposes a render device to the container, and RAW support only matters if you keep camera files. Both variants are built for `linux/amd64` and `linux/arm64`.
 
@@ -28,7 +28,7 @@ They are also on Docker Hub under the same tags.
 
 `latest` and `latest-lean` follow `main`, so a fix reaches them without waiting
 for a release. Every build is also published under the version in
-`package.json` — `3.3.0`, `3.3.0-lean` — republished for as long as that
+`package.json` — `3.4.0`, `3.4.0-lean` — republished for as long as that
 version is current, and left alone once the next one is cut.
 
 Only the last two versions stay published: on Docker Hub the older one is

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -6,6 +6,51 @@ Releases up to v2.0.7 were made upstream, at https://github.com/vikramsoni2/next
 
 Releases are listed newest to oldest.
 
+## v3.4.0 (2026-09-09)
+
+[GitHub release](https://github.com/cerede2000/NextExplorer/releases/tag/v3.4.0)
+
+### Sign in with a username
+
+Asked for in [#5](https://github.com/cerede2000/NextExplorer/issues/5), and the
+reason is a fair one: a username is what somebody chose, an email address is
+what their mail provider gave them. The sign-in box now takes either, and the
+server works out which it was handed. Case does not matter for either.
+
+The field itself was part of the problem. It was `type="email"`, so the browser
+refused a bare name before anything was ever sent — the server never saw those
+attempts at all.
+
+Two things had to be settled first, and both are worth knowing about.
+
+A username is not unique in the database. The constraint was lost in an early
+migration, and a username is derived from the local part of the address, so
+`alice@example.com` and `alice@other.org` both become `alice`. A name that
+answers for two accounts identifies neither, and choosing between them would be
+choosing whose account a stranger signs into — so it signs nobody in, and those
+accounts keep their email address, which is unambiguous by construction. New
+accounts and renames are now refused when they would take a username already in
+use, so no more are created. An installation that already holds duplicates can
+free the name by giving one of the accounts a different one.
+
+And the lockout after repeated failures used to be counted against whatever was
+typed. One account answering to two names would have had one budget of attempts
+per name, and anyone alternating between them would never have exhausted
+either. It is now counted against the account. The counters reset once on
+upgrade, which costs at most fifteen minutes of an existing lockout.
+
+### Running as root, written down
+
+[#6](https://github.com/cerede2000/NextExplorer/issues/6) asked how to run the
+server as root to reach a root-owned mount, and tried Compose's `user: root`
+without effect. That is not the knob: the entrypoint always finishes with
+`gosu appuser`, so `user:` decides who runs the entrypoint — already root — and
+not who runs the server. `PUID=0` and `PGID=0` do, and nothing said so.
+
+[Running as root](/configuration/environment#running-as-root) now explains it,
+along with what it costs: every file created on the host is owned by root, and
+a mount of `/` hands over the whole host.
+
 ## v3.3.0 (2026-09-03)
 
 [GitHub release](https://github.com/cerede2000/NextExplorer/releases/tag/v3.3.0)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/api/auth.api.js
+++ b/frontend/src/api/auth.api.js
@@ -12,10 +12,17 @@ const setupAccount = ({ email, username, password }) =>
 
 const fetchCurrentUser = () => requestJson('/api/auth/me', { method: 'GET' });
 
-const login = ({ email, password }) =>
+/**
+ * Sign in with an email address or a username.
+ *
+ * One box on screen, one field on the wire: the server decides which of the
+ * two it was handed, because only the server can tell whether a name belongs
+ * to exactly one account.
+ */
+const login = ({ identifier, password }) =>
   requestJson('/api/auth/login', {
     method: 'POST',
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ identifier, password }),
   });
 
 const logout = () =>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -143,7 +143,8 @@
     "label": "Meine freigegebenen Dateien",
     "path": "z. B. Bilder/Urlaub",
     "search": "Dateien und Ordner durchsuchen…",
-    "volumeLabel": "z. B. Dokumente, Projekte, Medien"
+    "volumeLabel": "z. B. Dokumente, Projekte, Medien",
+    "emailOrUsername": "name{'@'}firma.de oder name"
   },
   "loading": {
     "default": "Wird geladen…",
@@ -183,11 +184,12 @@
     "labelRequired": "Bezeichnung ist erforderlich",
     "pathRequired": "Pfad ist erforderlich",
     "saveVolume": "Volume konnte nicht gespeichert werden",
-    "removeVolume": "Volume konnte nicht entfernt werden"
+    "removeVolume": "Volume konnte nicht entfernt werden",
+    "identifierRequired": "E-Mail-Adresse oder Benutzername ist erforderlich"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Authentifizierung erforderlich",
-    "AUTH_INVALID_CREDENTIALS": "Ungültige E-Mail oder Passwort",
+    "AUTH_INVALID_CREDENTIALS": "Ungültige Anmeldedaten",
     "AUTH_ACCOUNT_LOCKED": "Das Konto ist aufgrund fehlgeschlagener Anmeldeversuche vorübergehend gesperrt",
     "AUTH_PASSWORD_INCORRECT": "Das aktuelle Passwort ist falsch",
     "VALIDATION_EMAIL_REQUIRED": "E-Mail ist erforderlich",
@@ -402,7 +404,8 @@
     "confirmPassword": "Passwort bestätigen",
     "sso": {
       "continue": "Mit Single Sign-On fortfahren"
-    }
+    },
+    "emailOrUsername": "E-Mail-Adresse oder Benutzername"
   },
   "breadcrumb": {
     "volumes": "Volumes",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -143,7 +143,8 @@
     "label": "My Shared Files",
     "path": "e.g. Pictures/Holidays",
     "search": "Search files and folders…",
-    "volumeLabel": "e.g. Documents, Projects, Media"
+    "volumeLabel": "e.g. Documents, Projects, Media",
+    "emailOrUsername": "name{'@'}company.com or name"
   },
   "loading": {
     "default": "Loading…",
@@ -183,11 +184,12 @@
     "labelRequired": "Label is required",
     "pathRequired": "Path is required",
     "saveVolume": "Failed to save volume",
-    "removeVolume": "Failed to remove volume"
+    "removeVolume": "Failed to remove volume",
+    "identifierRequired": "An email address or username is required"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Authentication required",
-    "AUTH_INVALID_CREDENTIALS": "Invalid email or password",
+    "AUTH_INVALID_CREDENTIALS": "Invalid credentials",
     "AUTH_ACCOUNT_LOCKED": "Account is temporarily locked due to failed login attempts",
     "AUTH_PASSWORD_INCORRECT": "Current password is incorrect",
     "VALIDATION_EMAIL_REQUIRED": "Email is required",
@@ -405,7 +407,8 @@
     "confirmPassword": "Confirm password",
     "sso": {
       "continue": "Continue with Single Sign-On"
-    }
+    },
+    "emailOrUsername": "Email address or username"
   },
   "breadcrumb": {
     "volumes": "Volumes",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -143,7 +143,8 @@
     "label": "Mis archivos compartidos",
     "path": "p. ej. Imágenes/Vacaciones",
     "search": "Buscar archivos y carpetas…",
-    "volumeLabel": ""
+    "volumeLabel": "",
+    "emailOrUsername": "nombre{'@'}empresa.com o nombre"
   },
   "loading": {
     "default": "Cargando…",
@@ -183,11 +184,12 @@
     "labelRequired": "",
     "pathRequired": "",
     "saveVolume": "",
-    "removeVolume": ""
+    "removeVolume": "",
+    "identifierRequired": "Se requiere un correo electrónico o un nombre de usuario"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Se requiere autenticación",
-    "AUTH_INVALID_CREDENTIALS": "Correo electrónico o contraseña no válidos",
+    "AUTH_INVALID_CREDENTIALS": "Credenciales no válidas",
     "AUTH_ACCOUNT_LOCKED": "La cuenta está bloqueada temporalmente debido a intentos fallidos de inicio de sesión",
     "AUTH_PASSWORD_INCORRECT": "La contraseña actual es incorrecta",
     "VALIDATION_EMAIL_REQUIRED": "El correo electrónico es obligatorio",
@@ -402,7 +404,8 @@
     "confirmPassword": "Confirmar contraseña",
     "sso": {
       "continue": "Continuar con inicio de sesión único"
-    }
+    },
+    "emailOrUsername": "Correo electrónico o nombre de usuario"
   },
   "breadcrumb": {
     "volumes": "Volúmenes",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -143,7 +143,8 @@
     "label": "Mes fichiers partagés",
     "path": "ex. Images/Vacances",
     "search": "Rechercher des fichiers et des dossiers…",
-    "volumeLabel": "ex. Documents, Projets, Médias"
+    "volumeLabel": "ex. Documents, Projets, Médias",
+    "emailOrUsername": "nom{'@'}entreprise.com ou nom"
   },
   "loading": {
     "default": "Chargement…",
@@ -183,11 +184,12 @@
     "labelRequired": "Le libellé est obligatoire",
     "pathRequired": "Le chemin est obligatoire",
     "saveVolume": "Échec de l'enregistrement du volume",
-    "removeVolume": "Échec de la suppression du volume"
+    "removeVolume": "Échec de la suppression du volume",
+    "identifierRequired": "Une adresse e-mail ou un nom d'utilisateur est requis"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Authentification requise",
-    "AUTH_INVALID_CREDENTIALS": "E-mail ou mot de passe invalide",
+    "AUTH_INVALID_CREDENTIALS": "Identifiants invalides",
     "AUTH_ACCOUNT_LOCKED": "Le compte est temporairement verrouillé en raison de tentatives de connexion échouées",
     "AUTH_PASSWORD_INCORRECT": "Le mot de passe actuel est incorrect",
     "VALIDATION_EMAIL_REQUIRED": "L'e-mail est obligatoire",
@@ -405,7 +407,8 @@
     "confirmPassword": "Confirmer le mot de passe",
     "sso": {
       "continue": "Continuer avec l'authentification unique"
-    }
+    },
+    "emailOrUsername": "Adresse e-mail ou nom d'utilisateur"
   },
   "breadcrumb": {
     "volumes": "Volumes",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -143,7 +143,8 @@
     "label": "मेरी साझा की गई फ़ाइलें",
     "path": "उदाहरण: Pictures/Holidays",
     "search": "फ़ाइलें और फ़ोल्डर खोजें…",
-    "volumeLabel": "जैसे दस्तावेज़, प्रोजेक्ट, मीडिया"
+    "volumeLabel": "जैसे दस्तावेज़, प्रोजेक्ट, मीडिया",
+    "emailOrUsername": "naam{'@'}company.com या naam"
   },
   "loading": {
     "default": "लोड हो रहा है…",
@@ -183,11 +184,12 @@
     "labelRequired": "लेबल आवश्यक है",
     "pathRequired": "पथ आवश्यक है",
     "saveVolume": "वॉल्यूम सहेजा नहीं जा सका",
-    "removeVolume": "वॉल्यूम हटाया नहीं जा सका"
+    "removeVolume": "वॉल्यूम हटाया नहीं जा सका",
+    "identifierRequired": "ईमेल पता या उपयोगकर्ता नाम आवश्यक है"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "प्रमाणीकरण आवश्यक है",
-    "AUTH_INVALID_CREDENTIALS": "अमान्य ईमेल या पासवर्ड",
+    "AUTH_INVALID_CREDENTIALS": "अमान्य प्रमाण-पत्र",
     "AUTH_ACCOUNT_LOCKED": "असफल लॉगिन प्रयासों के कारण खाता अस्थायी रूप से लॉक है",
     "AUTH_PASSWORD_INCORRECT": "वर्तमान पासवर्ड गलत है",
     "VALIDATION_EMAIL_REQUIRED": "ईमेल आवश्यक है",
@@ -402,7 +404,8 @@
     "confirmPassword": "पासवर्ड की पुष्टि करें",
     "sso": {
       "continue": "सिंगल साइन-ऑन के साथ जारी रखें"
-    }
+    },
+    "emailOrUsername": "ईमेल पता या उपयोगकर्ता नाम"
   },
   "breadcrumb": {
     "volumes": "वॉल्यूम",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -143,7 +143,8 @@
     "label": "I miei file condivisi",
     "path": "es. Immagini/Vacanze",
     "search": "Cerca file e cartelle…",
-    "volumeLabel": "es. Documenti, Progetti, Media"
+    "volumeLabel": "es. Documenti, Progetti, Media",
+    "emailOrUsername": "nome{'@'}azienda.it o nome"
   },
   "loading": {
     "default": "Caricamento…",
@@ -183,11 +184,12 @@
     "labelRequired": "L'etichetta è obbligatoria",
     "pathRequired": "Il percorso è obbligatorio",
     "saveVolume": "Impossibile salvare il volume",
-    "removeVolume": "Impossibile rimuovere il volume"
+    "removeVolume": "Impossibile rimuovere il volume",
+    "identifierRequired": "È richiesto un indirizzo email o un nome utente"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Autenticazione richiesta",
-    "AUTH_INVALID_CREDENTIALS": "Email o password non validi",
+    "AUTH_INVALID_CREDENTIALS": "Credenziali non valide",
     "AUTH_ACCOUNT_LOCKED": "L'account è temporaneamente bloccato a causa di tentativi di accesso falliti",
     "AUTH_PASSWORD_INCORRECT": "La password corrente è errata",
     "VALIDATION_EMAIL_REQUIRED": "L'email è obbligatoria",
@@ -402,7 +404,8 @@
     "confirmPassword": "Conferma password",
     "sso": {
       "continue": "Continua con Single Sign-On"
-    }
+    },
+    "emailOrUsername": "Indirizzo email o nome utente"
   },
   "breadcrumb": {
     "volumes": "Volumi",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -143,7 +143,8 @@
     "label": "내 공유 파일",
     "path": "예시: 사진/여행",
     "search": "파일 또는 폴더를 검색하세요…",
-    "volumeLabel": "예시: 문서, 프로젝트, 영상"
+    "volumeLabel": "예시: 문서, 프로젝트, 영상",
+    "emailOrUsername": "name{'@'}company.com 또는 name"
   },
   "loading": {
     "default": "로딩 중…",
@@ -183,11 +184,12 @@
     "labelRequired": "레이블이 필요합니다",
     "pathRequired": "경로가 필요합니다",
     "saveVolume": "볼륨 저장 실패",
-    "removeVolume": "볼륨 제거 실패"
+    "removeVolume": "볼륨 제거 실패",
+    "identifierRequired": "이메일 주소 또는 사용자 이름이 필요합니다"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "인증이 필요합니다",
-    "AUTH_INVALID_CREDENTIALS": "이메일 혹은 비밀번호가 일치하지 않습니다",
+    "AUTH_INVALID_CREDENTIALS": "잘못된 자격 증명",
     "AUTH_ACCOUNT_LOCKED": "로그인 실패로 인해 계정이 일시 잠금 처리되었습니다",
     "AUTH_PASSWORD_INCORRECT": "현재 비밀번호가 일치하지 않습니다",
     "VALIDATION_EMAIL_REQUIRED": "이메일 주소가 필요합니다",
@@ -402,7 +404,8 @@
     "confirmPassword": "비밀번호 확인",
     "sso": {
       "continue": "SSO(Single Sign-On)로 계속"
-    }
+    },
+    "emailOrUsername": "이메일 주소 또는 사용자 이름"
   },
   "breadcrumb": {
     "volumes": "볼륨",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -143,7 +143,8 @@
     "label": "Moje udostępnione pliki",
     "path": "np. Obrazy/Wakacje",
     "search": "Szukaj plików i folderów…",
-    "volumeLabel": "np. Dokumenty, Projekty, Multimedia"
+    "volumeLabel": "np. Dokumenty, Projekty, Multimedia",
+    "emailOrUsername": "imie{'@'}firma.pl lub nazwa"
   },
   "loading": {
     "default": "Ładowanie…",
@@ -183,11 +184,12 @@
     "labelRequired": "Etykieta jest wymagana",
     "pathRequired": "Ścieżka jest wymagana",
     "saveVolume": "Nie udało się zapisać wolumenu",
-    "removeVolume": "Nie udało się usunąć wolumenu"
+    "removeVolume": "Nie udało się usunąć wolumenu",
+    "identifierRequired": "Wymagany jest adres e-mail lub nazwa użytkownika"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Wymagana autentykacja",
-    "AUTH_INVALID_CREDENTIALS": "Nieprawidłowy adres e-mail lub hasło",
+    "AUTH_INVALID_CREDENTIALS": "Nieprawidłowe dane logowania",
     "AUTH_ACCOUNT_LOCKED": "Konto jest tymczasowo zablokowane z powodu nieudanych prób logowania",
     "AUTH_PASSWORD_INCORRECT": "Obecne hasło jest nieprawidłowe",
     "VALIDATION_EMAIL_REQUIRED": "Adres e-mail jest wymagany",
@@ -402,7 +404,8 @@
     "confirmPassword": "Potwierdź hasło",
     "sso": {
       "continue": "Kontynuuj z logowaniem jednokrotnym"
-    }
+    },
+    "emailOrUsername": "Adres e-mail lub nazwa użytkownika"
   },
   "breadcrumb": {
     "volumes": "Woluminy",

--- a/frontend/src/i18n/locales/pt-BR.json
+++ b/frontend/src/i18n/locales/pt-BR.json
@@ -143,7 +143,8 @@
     "label": "Meus Arquivos Compartilhados",
     "path": "ex.: Fotos/Férias",
     "search": "Pesquisar arquivos e pastas…",
-    "volumeLabel": "ex.: Documentos, Projetos, Mídia"
+    "volumeLabel": "ex.: Documentos, Projetos, Mídia",
+    "emailOrUsername": "nome{'@'}empresa.com ou nome"
   },
   "loading": {
     "default": "Carregando…",
@@ -183,11 +184,12 @@
     "labelRequired": "O rótulo é obrigatório",
     "pathRequired": "O caminho é obrigatório",
     "saveVolume": "Falha ao salvar volume",
-    "removeVolume": "Falha ao remover volume"
+    "removeVolume": "Falha ao remover volume",
+    "identifierRequired": "É necessário um e-mail ou nome de usuário"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Autenticação necessária",
-    "AUTH_INVALID_CREDENTIALS": "E-mail ou senha inválidos",
+    "AUTH_INVALID_CREDENTIALS": "Credenciais inválidas",
     "AUTH_ACCOUNT_LOCKED": "A conta está temporariamente bloqueada devido a tentativas de login com falha",
     "AUTH_PASSWORD_INCORRECT": "A senha atual está incorreta",
     "VALIDATION_EMAIL_REQUIRED": "O e-mail é obrigatório",
@@ -405,7 +407,8 @@
     "confirmPassword": "Confirmar senha",
     "sso": {
       "continue": "Continuar com Single Sign-On"
-    }
+    },
+    "emailOrUsername": "E-mail ou nome de usuário"
   },
   "breadcrumb": {
     "volumes": "Volumes",

--- a/frontend/src/i18n/locales/ro.json
+++ b/frontend/src/i18n/locales/ro.json
@@ -143,7 +143,8 @@
     "label": "Fișierele mele partajate",
     "path": "ex. Imagini/Vacanțe",
     "search": "Caută fișiere și dosare…",
-    "volumeLabel": "ex. Documente, Proiecte, Media"
+    "volumeLabel": "ex. Documente, Proiecte, Media",
+    "emailOrUsername": "nume{'@'}companie.ro sau nume"
   },
   "loading": {
     "default": "Se încarcă…",
@@ -183,11 +184,12 @@
     "labelRequired": "Eticheta este obligatorie",
     "pathRequired": "Calea este obligatorie",
     "saveVolume": "Nu s-a putut salva volumul",
-    "removeVolume": "Nu s-a putut elimina volumul"
+    "removeVolume": "Nu s-a putut elimina volumul",
+    "identifierRequired": "Este necesară o adresă de e-mail sau un nume de utilizator"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Autentificare necesară",
-    "AUTH_INVALID_CREDENTIALS": "Email sau parolă invalidă",
+    "AUTH_INVALID_CREDENTIALS": "Date de autentificare invalide",
     "AUTH_ACCOUNT_LOCKED": "Contul este blocat temporar din cauza încercărilor eșuate de autentificare",
     "AUTH_PASSWORD_INCORRECT": "Parola curentă este incorectă",
     "VALIDATION_EMAIL_REQUIRED": "Email-ul este obligatoriu",
@@ -402,7 +404,8 @@
     "confirmPassword": "Confirmă parola",
     "sso": {
       "continue": "Continuă cu Single Sign-On"
-    }
+    },
+    "emailOrUsername": "Adresă de e-mail sau nume de utilizator"
   },
   "breadcrumb": {
     "volumes": "Volume",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -143,7 +143,8 @@
     "label": "Мои общие файлы",
     "path": "например, Pictures/Holidays",
     "search": "Поиск файлов и папок…",
-    "volumeLabel": "например, Документы, Проекты, Медиа"
+    "volumeLabel": "например, Документы, Проекты, Медиа",
+    "emailOrUsername": "имя{'@'}компания.ru или имя"
   },
   "loading": {
     "default": "Загрузка…",
@@ -183,11 +184,12 @@
     "labelRequired": "Требуется метка",
     "pathRequired": "Требуется путь",
     "saveVolume": "Не удалось сохранить том",
-    "removeVolume": "Не удалось удалить том"
+    "removeVolume": "Не удалось удалить том",
+    "identifierRequired": "Требуется адрес электронной почты или имя пользователя"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Требуется аутентификация",
-    "AUTH_INVALID_CREDENTIALS": "Неверная электронная почта или пароль",
+    "AUTH_INVALID_CREDENTIALS": "Неверные учётные данные",
     "AUTH_ACCOUNT_LOCKED": "Учетная запись временно заблокирована из-за неудачных попыток входа",
     "AUTH_PASSWORD_INCORRECT": "Текущий пароль неверен",
     "VALIDATION_EMAIL_REQUIRED": "Требуется электронная почта",
@@ -402,7 +404,8 @@
     "confirmPassword": "Подтвердите пароль",
     "sso": {
       "continue": "Продолжить через Single Sign-On"
-    }
+    },
+    "emailOrUsername": "Адрес электронной почты или имя пользователя"
   },
   "breadcrumb": {
     "volumes": "Тома",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -143,7 +143,8 @@
     "label": "Mina utdelade filer",
     "path": "t.ex. Bilder/Semestrar",
     "search": "Sök efter filer och mappar…",
-    "volumeLabel": "t.ex. Dokument, Projekt, Media"
+    "volumeLabel": "t.ex. Dokument, Projekt, Media",
+    "emailOrUsername": "namn{'@'}foretag.se eller namn"
   },
   "loading": {
     "default": "Läser in…",
@@ -183,11 +184,12 @@
     "labelRequired": "Etikett krävs",
     "pathRequired": "Sökväg krävs",
     "saveVolume": "Det gick inte att spara volymen",
-    "removeVolume": "Det gick inte att ta bort volymen"
+    "removeVolume": "Det gick inte att ta bort volymen",
+    "identifierRequired": "En e-postadress eller ett användarnamn krävs"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "Autentisering krävs",
-    "AUTH_INVALID_CREDENTIALS": "Ogiltig e-post eller lösenord",
+    "AUTH_INVALID_CREDENTIALS": "Ogiltiga inloggningsuppgifter",
     "AUTH_ACCOUNT_LOCKED": "Kontot är tillfälligt låst på grund av misslyckade inloggningsförsök",
     "AUTH_PASSWORD_INCORRECT": "Det nuvarande lösenordet är felaktigt",
     "VALIDATION_EMAIL_REQUIRED": "E-post krävs",
@@ -402,7 +404,8 @@
     "confirmPassword": "Bekräfta lösenordet",
     "sso": {
       "continue": "Fortsätt med enkel inloggning"
-    }
+    },
+    "emailOrUsername": "E-postadress eller användarnamn"
   },
   "breadcrumb": {
     "volumes": "Volymer",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -143,7 +143,8 @@
     "label": "我的共享文件",
     "path": "例如：Pictures/Holidays",
     "search": "搜索文件和文件夹…",
-    "volumeLabel": "例如：文档、项目、媒体"
+    "volumeLabel": "例如：文档、项目、媒体",
+    "emailOrUsername": "name{'@'}company.com 或 name"
   },
   "loading": {
     "default": "加载中…",
@@ -183,11 +184,12 @@
     "labelRequired": "必须填写标签",
     "pathRequired": "必须填写路径",
     "saveVolume": "无法保存卷",
-    "removeVolume": "无法移除卷"
+    "removeVolume": "无法移除卷",
+    "identifierRequired": "需要邮箱地址或用户名"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "需要身份验证",
-    "AUTH_INVALID_CREDENTIALS": "电子邮件或密码无效",
+    "AUTH_INVALID_CREDENTIALS": "凭据无效",
     "AUTH_ACCOUNT_LOCKED": "由于登录尝试失败，账户已被临时锁定",
     "AUTH_PASSWORD_INCORRECT": "当前密码不正确",
     "VALIDATION_EMAIL_REQUIRED": "电子邮件为必填项",
@@ -402,7 +404,8 @@
     "confirmPassword": "确认密码",
     "sso": {
       "continue": "使用单点登录继续"
-    }
+    },
+    "emailOrUsername": "邮箱地址或用户名"
   },
   "breadcrumb": {
     "volumes": "卷",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -143,7 +143,8 @@
     "label": "我的分享檔案",
     "path": "例如：Pictures/Holidays",
     "search": "搜尋檔案和檔案夾…",
-    "volumeLabel": "例如：Documents, Projects, Media"
+    "volumeLabel": "例如：Documents, Projects, Media",
+    "emailOrUsername": "name{'@'}company.com 或 name"
   },
   "loading": {
     "default": "載入中…",
@@ -183,11 +184,12 @@
     "labelRequired": "需要標籤",
     "pathRequired": "需要路徑",
     "saveVolume": "儲存儲存卷失敗",
-    "removeVolume": "移除儲存卷失敗"
+    "removeVolume": "移除儲存卷失敗",
+    "identifierRequired": "需要電子郵件地址或使用者名稱"
   },
   "serverErrors": {
     "AUTH_REQUIRED": "需要身份驗證",
-    "AUTH_INVALID_CREDENTIALS": "電子郵件或密碼無效",
+    "AUTH_INVALID_CREDENTIALS": "認證資訊無效",
     "AUTH_ACCOUNT_LOCKED": "由於登入嘗試失敗，帳戶已暫時鎖定",
     "AUTH_PASSWORD_INCORRECT": "目前密碼不正確",
     "VALIDATION_EMAIL_REQUIRED": "電子郵件為必填",
@@ -402,7 +404,8 @@
     "confirmPassword": "確認密碼",
     "sso": {
       "continue": "使用單一登入繼續"
-    }
+    },
+    "emailOrUsername": "電子郵件地址或使用者名稱"
   },
   "breadcrumb": {
     "volumes": "儲存卷",

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -84,9 +84,9 @@ export const useAuthStore = defineStore('auth', () => {
     sessionStorage.removeItem('guestSessionId');
   };
 
-  const login = async ({ email, password }) => {
+  const login = async ({ identifier, password }) => {
     lastError.value = null;
-    const response = await loginApi({ email, password });
+    const response = await loginApi({ identifier, password });
     hasStatus.value = true;
     currentUser.value = response?.user || null;
 

--- a/frontend/src/views/AuthLoginView.identifier.spec.js
+++ b/frontend/src/views/AuthLoginView.identifier.spec.js
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+/**
+ * The one box on the sign-in screen.
+ *
+ * Issue #5 asked to sign in with a username rather than an email address. The
+ * box that used to refuse one was not the server: `type="email"` meant the
+ * browser rejected a bare name before anything was ever sent, so the field
+ * itself had to stop claiming to be an address.
+ */
+
+const auth = vi.hoisted(() => ({ store: null }));
+const login = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock('@/stores/auth', async () => {
+  const { reactive } = await import('vue');
+  auth.store = reactive({
+    hasStatus: true,
+    isLoading: false,
+    isAuthenticated: false,
+    requiresSetup: false,
+    lastError: '',
+    strategies: { local: true, oidc: false },
+    login,
+    ensureStatus: vi.fn(async () => {}),
+    clearError: vi.fn(),
+  });
+  return { useAuthStore: () => auth.store };
+});
+
+vi.mock('@/stores/features', () => ({
+  useFeaturesStore: () => ({ version: '3.4.0', demoLogin: null, ensureLoaded: vi.fn(async () => {}) }),
+}));
+vi.mock('@/stores/appSettings', () => ({ useAppSettings: () => ({ ensureLoaded: vi.fn() }) }));
+vi.mock('@/api', () => ({ apiBase: '' }));
+
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useI18n: () => ({ t: (key) => key }),
+}));
+
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue');
+  const route = reactive({ query: {}, path: '/login' });
+  return {
+    useRoute: () => route,
+    useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+    onBeforeRouteUpdate: () => {},
+  };
+});
+
+vi.mock('@/layouts/AuthLayout.vue', () => ({
+  default: { name: 'AuthLayoutStub', template: '<div><slot name="heading" /><slot /></div>' },
+}));
+
+const AuthLoginView = (await import('./AuthLoginView.vue')).default;
+
+let wrapper = null;
+
+const mountLogin = async () => {
+  wrapper = mount(AuthLoginView, {
+    global: { mocks: { $t: (key) => key } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper.vm;
+};
+
+const field = () => document.querySelector('#login-identifier');
+
+beforeEach(() => {
+  login.mockClear();
+  login.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = '';
+});
+
+describe('the box someone types their name into', () => {
+  /** `type="email"` is the browser refusing a username before we ever see it. */
+  it('does not claim to hold an address', async () => {
+    await mountLogin();
+
+    expect(field().getAttribute('type')).toBe('text');
+  });
+
+  it('offers the saved username rather than the saved address', async () => {
+    await mountLogin();
+
+    expect(field().getAttribute('autocomplete')).toBe('username');
+  });
+
+  it('sends a username as it was typed', async () => {
+    const view = await mountLogin();
+    view.loginIdentifier = 'alice';
+    view.loginPasswordValue = 'motdepasse';
+
+    await view.handleLoginSubmit();
+
+    expect(login).toHaveBeenCalledWith({ identifier: 'alice', password: 'motdepasse' });
+  });
+
+  it('sends an address the same way', async () => {
+    const view = await mountLogin();
+    view.loginIdentifier = 'alice@example.com';
+    view.loginPasswordValue = 'motdepasse';
+
+    await view.handleLoginSubmit();
+
+    expect(login).toHaveBeenCalledWith({
+      identifier: 'alice@example.com',
+      password: 'motdepasse',
+    });
+  });
+
+  it('trims what was typed around it', async () => {
+    const view = await mountLogin();
+    view.loginIdentifier = '  alice  ';
+    view.loginPasswordValue = 'motdepasse';
+
+    await view.handleLoginSubmit();
+
+    expect(login.mock.calls[0][0].identifier).toBe('alice');
+  });
+
+  it('asks for one before sending anything', async () => {
+    const view = await mountLogin();
+    view.loginIdentifier = '   ';
+    view.loginPasswordValue = 'motdepasse';
+
+    await view.handleLoginSubmit();
+
+    expect(login).not.toHaveBeenCalled();
+    expect(view.loginError).toBe('errors.identifierRequired');
+  });
+});

--- a/frontend/src/views/AuthLoginView.vue
+++ b/frontend/src/views/AuthLoginView.vue
@@ -17,7 +17,7 @@ const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 
-const loginEmailValue = ref('');
+const loginIdentifier = ref('');
 const loginPasswordValue = ref('');
 const loginError = ref('');
 const isSubmittingLogin = ref(false);
@@ -78,8 +78,8 @@ onMounted(async () => {
     // friction for nothing. The server only ever sends this in demo mode, and
     // an empty form is left alone if someone has already started typing.
     const demoLogin = featuresStore.demoLogin;
-    if (demoLogin && !loginEmailValue.value && !loginPasswordValue.value) {
-      loginEmailValue.value = demoLogin.email;
+    if (demoLogin && !loginIdentifier.value && !loginPasswordValue.value) {
+      loginIdentifier.value = demoLogin.email;
       loginPasswordValue.value = demoLogin.password;
     }
   } catch (_) {
@@ -128,8 +128,8 @@ const handleLoginSubmit = async () => {
     return;
   }
 
-  if (!loginEmailValue.value.trim()) {
-    loginError.value = t('errors.emailRequired');
+  if (!loginIdentifier.value.trim()) {
+    loginError.value = t('errors.identifierRequired');
     return;
   }
 
@@ -142,10 +142,10 @@ const handleLoginSubmit = async () => {
 
   try {
     await auth.login({
-      email: loginEmailValue.value.trim(),
+      identifier: loginIdentifier.value.trim(),
       password: loginPasswordValue.value,
     });
-    loginEmailValue.value = '';
+    loginIdentifier.value = '';
     loginPasswordValue.value = '';
     redirectToDestination();
   } catch (error) {
@@ -191,14 +191,16 @@ const handleOidcLogin = () => {
 
     <form v-if="supportsLocal" class="space-y-5" @submit.prevent="handleLoginSubmit">
       <label class="block">
-        <span class="block text-sm font-medium text-white/80">{{ $t('auth.emailAddress') }}</span>
+        <span class="block text-sm font-medium text-white/80">{{
+          $t('auth.emailOrUsername')
+        }}</span>
         <input
-          id="login-email"
-          v-model="loginEmailValue"
-          type="email"
-          autocomplete="email"
+          id="login-identifier"
+          v-model="loginIdentifier"
+          type="text"
+          autocomplete="username"
           :class="inputBaseClasses"
-          :placeholder="$t('placeholders.emailCompany')"
+          :placeholder="$t('placeholders.emailOrUsername')"
           :disabled="isSubmittingLogin"
         />
       </label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextexplorer",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextexplorer",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "workspaces": [
         "backend",
         "frontend",
@@ -23,7 +23,7 @@
     },
     "backend": {
       "name": "finder",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "ISC",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
@@ -75,7 +75,7 @@
     },
     "frontend": {
       "name": "explorer",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "dependencies": {
         "@codemirror/language-data": "^6.3.2",
         "@coleqiu/vue-drag-select": "^2.0.6-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextexplorer",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "engines": {
     "node": ">=24 <25"


### PR DESCRIPTION
Closes #5. Answers #6.

Cut from `main` rather than from `integration`, so it can ship on its own without the test batch in flight.

## Signing in with a username (#5)

The route already looked as though it handled this — it read `email || username` — but the lookup underneath was `WHERE email = ?` alone. And the field was `type="email"`, so a browser refused a bare name before anything was sent.

Two things had to be settled first:

- **A username is not unique.** The constraint was lost in the v3 migration, and one is derived from the local part of the address — `alice@example.com` and `alice@other.org` both become `alice`. A name answering for two accounts signs nobody in; both keep their address, which is unique by schema. New accounts and renames that would take a name already in use are refused, so no more are made. Existing duplicates are left alone rather than renamed or cleared out from under their owners.
- **The lockout was keyed on what was typed.** One account with two names would have had one budget of failed attempts per name, and alternating between them would never have exhausted either. It is keyed on the account now.

## Running as root (#6)

No code change. The entrypoint always ends with `gosu appuser`, so Compose's `user:` decides who runs the entrypoint — already root — and not who runs the server. `PUID=0`/`PGID=0` do, and nothing said so. Documented, with what it costs.

## Verification

25 backend tests, 6 frontend, 17 mutations all caught. Both suites green, 14 catalogues in parity.